### PR TITLE
Improve Figma API error handling with detailed error messages

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -8,7 +8,14 @@ export async function getFigmaFileData(fileId) {
     });
 
     if (!response.ok) {
-        throw new Error(`Figma API error: ${response.statusText}`);
+        let errorMessage = `Figma API error: ${response.statusText}`;
+        try {
+            const errorBody = await response.json();
+            errorMessage += ` - ${JSON.stringify(errorBody)}`;
+        } catch (e) {
+            // If parsing JSON fails, continue with the original error message
+        }
+        throw new Error(errorMessage);
     }
 
     return response.json();


### PR DESCRIPTION
This pull request includes a change to the `getFigmaFileData` function in `src/utils/api.js` to improve error handling by providing more detailed error messages from the Figma API responses.

Improvements to error handling:

* [`src/utils/api.js`](diffhunk://#diff-1952ef38ecd8505652ac151cac71f96e74b799a2e23344fa5bf2e74f3a813ae3L11-R18): Enhanced the error message in the `getFigmaFileData` function to include the response body from the Figma API if available, providing more context for debugging. If parsing the JSON response fails, it continues with the original error message.